### PR TITLE
feat: add option to pass las content directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@
   const myLas = new Lasjs(`./sample/example1.las`);
   ```
 
+  You can also pass LAS file contents directly to constructor
+
+  ```js
+  // common js
+  const { Las } = require('las-js');
+  const fs = require('fs');
+  const data = fs.readFileSync(`./sample/example1.las`, { encoding: 'utf8' });
+  // add loadFile: false to constructor options
+  const myLas = new Lasjs(data, { loadFile: false });
+  ```
+
 > Browser
 
 las-js adds a global class Lasjs or using esm

--- a/src/__test__/node.test.js
+++ b/src/__test__/node.test.js
@@ -2,7 +2,10 @@
 const { Las } = require('../../dist/index');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
-const fs = require('fs').promises;
+const fs = require('fs');
+const { promisify } = require('util');
+const readFile = promisify(fs.readFile);
+
 // const path = require('path');
 const files = ['example1.las', '1046943371.las', 'A10.las', 'C1.las'];
 
@@ -35,8 +38,8 @@ describe('Raw las data', () => {
     "The decoded string shouldn't be empty for %s",
     async filename => {
       const file = path.resolve(__dirname, `./sample/${filename}`);
-      const data = await fs.readFile(file, {encoding: 'utf8'});
-      const myLas = new Las(data, {loadFile: false});
+      const data = await readFile(file, { encoding: 'utf8' });
+      const myLas = new Las(data, { loadFile: false });
       const blob = await myLas.blobString;
       expect(myLas.path).toEqual('');
       expect(blob.length).toBeGreaterThan(0);

--- a/src/__test__/node.test.js
+++ b/src/__test__/node.test.js
@@ -2,6 +2,7 @@
 const { Las } = require('../../dist/index');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
+const fs = require('fs').promises;
 // const path = require('path');
 const files = ['example1.las', '1046943371.las', 'A10.las', 'C1.las'];
 
@@ -24,6 +25,22 @@ describe('Blob', () => {
       const myLas = new Las(path.resolve(__dirname, `./sample/${filename}`));
       const blob = await myLas.blobString;
       expect(blob.length).toBeGreaterThan(0);
+    },
+    1000
+  );
+});
+
+describe('Raw las data', () => {
+  it.each(files)(
+    "The decoded string shouldn't be empty for %s",
+    async filename => {
+      const file = path.resolve(__dirname, `./sample/${filename}`);
+      const data = await fs.readFile(file, {encoding: 'utf8'});
+      const myLas = new Las(data, {loadFile: false});
+      const blob = await myLas.blobString;
+      expect(myLas.path).toEqual('');
+      expect(blob.length).toBeGreaterThan(0);
+      expect(blob).toEqual(data);
     },
     1000
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,15 @@ interface WellProps {
   [key: string]: { unit: string; value: string; description: string };
 }
 
+interface LasOptions {
+  /**
+   * Indicates whether Las needs to load file or not.
+   * If false Las will expect file content instead of file path.
+   * @default true
+   */
+  loadFile?: boolean;
+}
+
 export class Las {
   private static chunk<T>(arr: T[], size: number): T[][] {
     const overall = [];
@@ -39,12 +48,17 @@ export class Las {
   public blobString: Promise<string | void>;
   /**
    * Creates an instance of Las.
-   * @param {string} path - Absolute path to las file
+   * @param {string} path - Absolute path to las file or las file contents
    * @memberof Las
    */
-  constructor(path: string | File) {
-    this.path = path;
-    this.blobString = this.initialize();
+  constructor(path: string | File, { loadFile = true }: LasOptions = {}) {
+    if (loadFile) {
+      this.path = path;
+      this.blobString = this.initialize();
+    } else {
+      this.path = '';
+      this.blobString = Promise.resolve(path as string);
+    }
   }
 
   /**


### PR DESCRIPTION
I've added second argument to constructor with options. So it will make possible to pass las file contents directly in browser as well. And also it will be easy to extend in future.

Closes #13