### PR TITLE
Update Canadian Well Logging Society links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # las-js is a zero-dependency JavaScript library for parsing .Las file (Geophysical well log files).
 
-### Currently supports only version 2.0 of LAS Specification. For more information about this format, see the Canadian Well Logging Society [web page](http://www.cwls.org/las/)
+### Currently supports only version 2.0 of [LAS Specification](https://www.cwls.org/wp-content/uploads/2017/02/Las2_Update_Feb2017.pdf).  For more information about this format, see the Canadian Well Logging Society [product page](https://www.cwls.org/products/).
 
 ## How to use
 


### PR DESCRIPTION
Fix Canadian Well Logging Society links to go to the current active locations for LAS information and specifications.