### PR TITLE
fix: better regex for data

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -185,7 +185,7 @@ class Las {
     const hds = await this.header();
     const totalheadersLength = hds.length;
     const sB = (s as string)
-      .split(/~A(?:[\x00-\x7F])*\n/)[1]
+      .split(/~A(?:[\x20-\x7E])*(?:\r\n|\r|\n)/)[1]
       .trim()
       .split(/\s+/)
       .map(m => Las.convertToValue(m.trim()));
@@ -208,7 +208,7 @@ class Las {
     const nullValue = well.NULL.value;
     const totalheadersLength = hds.length;
     const sB = (s as string)
-      .split(/~A(?:[\x00-\x7F])*\n/)[1]
+      .split(/~A(?:[\x20-\x7E])*(?:\r\n|\r|\n)/)[1]
       .trim()
       .split(/\s+/)
       .map(m => Las.convertToValue(m.trim()));

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ export class Las {
     const hds = await this.header();
     const totalheadersLength = hds.length;
     const sB = (s as string)
-      .split(/~A(?:[\x00-\x7F])*\n/)[1]
+      .split(/~A(?:[\x20-\x7E])*(?:\r\n|\r|\n)/)[1]
       .trim()
       .split(/\s+/)
       .map(m => Las.convertToValue(m.trim()));
@@ -201,7 +201,7 @@ export class Las {
     const nullValue = well.NULL.value;
     const totalheadersLength = hds.length;
     const sB = (s as string)
-      .split(/~A(?:[\x00-\x7F])*\n/)[1]
+      .split(/~A(?:[\x20-\x7E])*(?:\r\n|\r|\n)/)[1]
       .trim()
       .split(/\s+/)
       .map(m => Las.convertToValue(m.trim()));


### PR DESCRIPTION
I've tested new version on my collection of LAS files and some of them were saved with `\r` instead of `\n` in the end data header. So that's why I've added `\r\n|\r|\n` to match all possible cases of end of string. Also I've removed non-printable characters from first part of regex, cause they are not actually valid for LAS format.

As for tests - it's hard to add, because on commit git usually replaces \r(CR) and \r\n(CRLF) with \n (LF). 